### PR TITLE
[FIX] Decode an image on Base64 OT246-59 🐛 

### DIFF
--- a/controllers/slides.js
+++ b/controllers/slides.js
@@ -84,7 +84,7 @@ module.exports = {
   }),
   post: catchAsync(async (req, res, next) => {
     try {
-      const slide = await createSlide(req.files, req.body)
+      const slide = await createSlide(req.body)
       endpointResponse({
         res,
         code: 200,

--- a/services/slides.js
+++ b/services/slides.js
@@ -55,24 +55,19 @@ exports.deleteSlide = async (id) => {
     throw new ErrorObject(err.message, 500)
   }
 }
-exports.createSlide = async (file, data) => {
-  const { image } = file
-  const { text, organizationId } = data
+exports.createSlide = async (data) => {
+  const { imageDataEncoded, text, organizationId } = data
   let order = null
-  if (!data.order) {
-    try {
+  try {
+    if (!data.order) {
       const slide = await Slide.findOne({
         order: [['order', 'DESC']],
       })
       order = slide.order + 1
-    } catch (err) {
-      throw new ErrorObject(err.message, err.statusCode || 500)
+    } else {
+      order = data.order
     }
-  } else {
-    order = data.order
-  }
-  try {
-    const imageUrl = await uploadFile(image)
+    const imageUrl = await uploadFile(imageDataEncoded, `slide${order}`)
     const slide = await Slide.create({
       imageUrl, text, order, organizationId,
     })

--- a/services/uploadFile.js
+++ b/services/uploadFile.js
@@ -12,6 +12,7 @@ const uploadFileAws = async (tempFile) => {
     Bucket: config.bucketName,
     Key: tempFile.name,
     Body: tempFile.data,
+    ContentType: 'image/jpeg',
   }
   try {
     const command = createCommand(input)

--- a/services/uploadFile.js
+++ b/services/uploadFile.js
@@ -1,3 +1,4 @@
+const { Buffer } = require('buffer')
 const { s3, createCommand } = require('./amazonS3')
 const { ErrorObject } = require('../helpers/error')
 
@@ -6,7 +7,7 @@ const config = {
   region: process.env.AWS_REGION,
 }
 
-exports.uploadFile = async (tempFile) => {
+const uploadFileAws = async (tempFile) => {
   const input = {
     Bucket: config.bucketName,
     Key: tempFile.name,
@@ -22,4 +23,14 @@ exports.uploadFile = async (tempFile) => {
   } catch (err) {
     throw new ErrorObject(err.message, 502)
   }
+}
+
+const decodeBase64 = (buffer64str) => Buffer.from(buffer64str, 'base64')
+
+exports.uploadFile = async (dataFile, name) => {
+  // 1. decode the file
+  const dataFileDecoded = decodeBase64(dataFile)
+  const nameFile = `${name}.jpg`
+  // 2 . upload file content
+  return uploadFileAws({ name: nameFile, data: dataFileDecoded })
 }


### PR DESCRIPTION
 ## Description

A POST /slide request must be made
You will receive the image to be stored in base 64. It must be decoded and stored in Amazon S3.
In the case of not receiving the order field, you must set it as the last one based on the existing ones

 ## Evidence 
![image](https://user-images.githubusercontent.com/38141029/182315115-0c475080-5966-4d16-a295-ff064b347333.png)

- Example of a decoded image upload😄
![image](https://user-images.githubusercontent.com/38141029/182342454-016846c2-30e2-4101-9f06-cc8ada1423e3.png)

- ListObjects in AWS Bucket
![image](https://user-images.githubusercontent.com/38141029/182314939-c40ffb8a-094b-425c-af13-93a83cf59246.png)


