### PR TITLE
[TEST] Test: Endpoints /members - OT296

### DIFF
--- a/test/members.test.js
+++ b/test/members.test.js
@@ -2,7 +2,7 @@ const request = require('supertest');
 const { expect } = require('chai');
 const app = require('../app');
 
-describe('Member success', () => {
+describe('Members endpoint test on success', () => {
   before(async () => {
     const response = await request(app)
       .post('/auth/login')
@@ -14,7 +14,7 @@ describe('Member success', () => {
     global.token = response.body.body;
   }),
 
-    describe('GET /members', () => {
+    describe('[GET - /members]', () => {
       it('Should GET all members', async () => {
         const response = await request(app)
           .get('/members')
@@ -24,7 +24,7 @@ describe('Member success', () => {
       }).timeout(5000);
     }),
 
-    describe('POST /members', () => {
+    describe('[POST - /members]', () => {
       it('Should create a new member', async () => {
         const response = await request(app)
           .post('/members')
@@ -39,7 +39,7 @@ describe('Member success', () => {
       });
     }),
 
-    describe('PUT /members', () => {
+    describe('[PUT - /members]', () => {
       it('Should update a member', async () => {
         const response = await request(app)
           .put('/members/1')
@@ -53,7 +53,7 @@ describe('Member success', () => {
         expect(response.body);
       }).timeout(5000);
     });
-  describe('DELETE /members', () => {
+  describe('[DELETE /members]', () => {
     it('Should delete a member', async () => {
       const response = await request(app)
         .delete('/members/1')
@@ -64,8 +64,8 @@ describe('Member success', () => {
   })
 });
 
-describe('Member failure request', () => {
-  describe('GET /members', () => {
+describe('Members endpoint failure request', () => {
+  describe('[GET - /members]', () => {
     it('Should return error unauthorized', async () => {
       const response = await request(app)
         .get('/members')
@@ -77,7 +77,7 @@ describe('Member failure request', () => {
     });
   }),
 
-    describe('POST /members', () => {
+    describe('[POST - /members]', () => {
       it('Should return error missing property', async () => {
         const response = await request(app)
           .post('/members')
@@ -90,7 +90,7 @@ describe('Member failure request', () => {
       });
     }),
 
-    describe('PUT /members/:id', () => {
+    describe('[PUT - /members/:id]', () => {
       it('Should return error missing member', async () => {
         const response = await request(app)
           .put('/members/22')
@@ -103,7 +103,7 @@ describe('Member failure request', () => {
       });
     }),
 
-    describe('DELETE /members/:id', () => {
+    describe('[DELETE - /members/:id]', () => {
       it('Should return error missing member', async () => {
         const response = await request(app)
           .delete('/members/66')

--- a/test/members.test.js
+++ b/test/members.test.js
@@ -1,0 +1,114 @@
+const request = require('supertest');
+const { expect } = require('chai');
+const app = require('../app');
+
+describe('Member success', () => {
+  before(async () => {
+    const response = await request(app)
+      .post('/auth/login')
+      .send({
+        email: 'rickyespinoza@mail.com',
+        password: 'ABC123_f',
+      })
+      .expect(200);
+    global.token = response.body.body;
+  }),
+
+    describe('GET /members', () => {
+      it('Should GET all members', async () => {
+        const response = await request(app)
+          .get('/members')
+          .set('Authorization', `Bearer ${global.token}`);
+        expect(response.statusCode).to.equal(200);
+        expect(response.body.members);
+      }).timeout(5000);
+    }),
+
+    describe('POST /members', () => {
+      it('Should create a new member', async () => {
+        const response = await request(app)
+          .post('/members')
+          .set('Authorization', `Bearer ${global.token}`)
+          .send({
+            name: 'Ricky',
+            image: 'https://rickyespinoza.com',
+            createdAt: new Date(),
+          });
+        expect(response.statusCode).to.equal(201);
+        expect(response.body);
+      });
+    }),
+
+    describe('PUT /members', () => {
+      it('Should update a member', async () => {
+        const response = await request(app)
+          .put('/members/1')
+          .set('Authorization', `Bearer ${global.token}`)
+          .send({
+            name: 'Jaime',
+            image: 'https://image.com/image.jpg',
+            createdAt: new Date(),
+          });
+        expect(response.statusCode).to.equal(200);
+        expect(response.body);
+      }).timeout(5000);
+    });
+  describe('DELETE /members', () => {
+    it('Should delete a member', async () => {
+      const response = await request(app)
+        .delete('/members/1')
+        .set('Authorization', `Bearer ${global.token}`);
+      expect(response.statusCode).to.equal(200);
+      expect(response.body);
+    }).timeout(5000);
+  })
+});
+
+describe('Member failure request', () => {
+  describe('GET /members', () => {
+    it('Should return error unauthorized', async () => {
+      const response = await request(app)
+        .get('/members')
+        .set(
+          'Authorization',
+          `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6ImhvcmFjaW9nQG1haWwuY29tIiwiaWF0IjoxNjYwMjYxMjUyLCJleHAiOjE2NjAyNjQ4NTJ9.cKKRe8l2aEhOHeD_GfZp1wwBt41A7btqBMFUxbHPew`
+        );
+      expect(response.statusCode).to.equal(401);
+    });
+  }),
+
+    describe('POST /members', () => {
+      it('Should return error missing property', async () => {
+        const response = await request(app)
+          .post('/members')
+          .set('Authorization', `Bearer ${global.token}`)
+          .send({
+            image: 'https://rickyespinoza.com',
+            createdAt: new Date(),
+          });
+        expect(response.statusCode).to.equal(400);
+      });
+    }),
+
+    describe('PUT /members/:id', () => {
+      it('Should return error missing member', async () => {
+        const response = await request(app)
+          .put('/members/22')
+          .set('Authorization', `Bearer ${global.token}`)
+          .send({
+            name: 'Gilian',
+            createdAt: new Date(),
+          });
+        expect(response.statusCode).to.equal(404);
+      });
+    }),
+
+    describe('DELETE /members/:id', () => {
+      it('Should return error missing member', async () => {
+        const response = await request(app)
+          .delete('/members/66')
+          .set('Authorization', `Bearer ${global.token}`);
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+});


### PR DESCRIPTION
AS developer
I WANT to have tests of the /members endpoints
TO ensure the integrity and operation of the project

Criteria of acceptance:
Test the correct response scenario, and error scenarios, such as non-existent ids, validations, permissions, etc. The file must be created inside the /test folder, with the same name as the endpoint. The test created as a demonstration can be used as a basis.

### EVIDENCE

![ot66](https://user-images.githubusercontent.com/85527959/184273229-1dcde730-8293-49e4-a4af-d076f58350d9.png)

![ot67](https://user-images.githubusercontent.com/85527959/184273235-f52bb2f3-7f86-4c76-9f54-2c422371db04.png)

