### PR TITLE
[TEST] Test: Endpoints /news OT246-98

### DIFF
--- a/test/news.test.js
+++ b/test/news.test.js
@@ -65,6 +65,19 @@ describe('news tests', () => {
           .that.has.property('id');
       });
     });
+
+    describe('[GET - /news/:id/comments', () => {
+      it('should return an array of comments', async () => {
+        const response = await request(app)
+          .get('/news/1/comments')
+          .set('Authorization', `Bearer ${userToken}`);
+
+        expect(response.statusCode).to.equal(200);
+
+        expect(response.body).to.have.property('body');
+        expect(Array.isArray(response.body.body)).to.be.true;
+      });
+    });
   });
 
   describe('news tests on failure', () => {
@@ -87,6 +100,22 @@ describe('news tests', () => {
         const response = await request(app)
           .get('/news/notanid')
           .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    describe('[GET - /news/:id/comments]', () => {
+      it('should return 401 if no token provided', async () => {
+        const response = await request(app).get('/news/1/comments');
+
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should return 404 if new is not found', async () => {
+        const response = await request(app)
+          .get('/news/notanid/comments')
+          .set('Authorization', `Bearer ${userToken}`);
 
         expect(response.statusCode).to.equal(404);
       });

--- a/test/news.test.js
+++ b/test/news.test.js
@@ -126,7 +126,7 @@ describe('news tests', () => {
     });
 
     after('Restore the deleted new so its easier to run the test again', async () => {
-      await New.update({ deletedAt: null }, { where: { id: 1 }, limit: 1 });
+      await New.restore({ where: { id: 1 }, limit: 1 });
     });
   });
 

--- a/test/news.test.js
+++ b/test/news.test.js
@@ -2,28 +2,94 @@ const { expect } = require('chai');
 const request = require('supertest');
 const app = require('../app')
 
-describe('news tests on success', () => {
-  describe('[GET - /news]', () => {
-    it('Should return paginated array of news', async () => {
-      const response = await request(app).get('/news');
 
-      expect(response.statusCode).to.equal(200);
+describe('news tests', () => {
+  let userToken, adminToken;
 
-      expect(response.body)
-        .to.have.property('body')
-        .that.has.property('urls');
+  before('get login tokens', async () => {
+    const userLoginResponse = await request(app)
+      .post('/auth/login')
+      .send({
+        email: 'usuariocomun1@mail.com',
+        password: 'ABCD_efgh_1234',
+      })
+      .expect(200);
 
-      const { body: { body } } = response;
+    userToken = userLoginResponse.body.body;
 
-      expect(body.urls)
-        .to.have.property('prevUrl')
-        .that.is.a.string;
+    const adminLoginResponse = await request(app)
+      .post('/auth/login')
+      .send({
+        email: 'usuarioadmin1@mail.com',
+        password: 'ABCZ_efgi_1230',
+      })
+      .expect(200);
 
-      expect(body.urls)
-        .to.have.property('nextUrl')
-        .that.is.a.string;
+    adminToken = adminLoginResponse.body.body;
+  });
 
-      expect(Array.isArray(body.news)).to.be.true;
+  describe('news tests on success', () => {
+    describe('[GET - /news]', () => {
+      it('Should return paginated array of news', async () => {
+        const response = await request(app).get('/news');
+
+        expect(response.statusCode).to.equal(200);
+
+        expect(response.body)
+          .to.have.property('body')
+          .that.has.property('urls');
+
+        const { body: { body } } = response;
+
+        expect(body.urls)
+          .to.have.property('prevUrl')
+          .that.is.a.string;
+
+        expect(body.urls)
+          .to.have.property('nextUrl')
+          .that.is.a.string;
+
+        expect(Array.isArray(body.news)).to.be.true;
+      });
+    });
+
+    describe('[GET - /news/:id]', () => {
+      it('should return a single new', async () => {
+        const response = await request(app)
+          .get('/news/1')
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.body)
+          .to.have.property('body')
+          .that.has.property('id');
+      });
+    });
+  });
+
+  describe('news tests on failure', () => {
+    describe('[GET - /news/:id]', () => {
+      it('should return 401 if no token provided', async () => {
+        const response = await request(app).get('/news/1');
+
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should return 403 if user is not an admin', async () => {
+        const response = await request(app)
+          .get('/news/1')
+          .set('Authorization', `Bearer ${userToken}`);
+
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('should return 404 if new is not found', async () => {
+        const response = await request(app)
+          .get('/news/notanid')
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.statusCode).to.equal(404);
+      });
     });
   });
 });

--- a/test/news.test.js
+++ b/test/news.test.js
@@ -78,6 +78,25 @@ describe('news tests', () => {
         expect(Array.isArray(response.body.body)).to.be.true;
       });
     });
+
+    describe('[POST - /news', () => {
+      it('should create a new', async () => {
+        const response = await request(app)
+          .post('/news')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({
+            name: 'title',
+            content: 'body',
+            image: 'https://foo.bar',
+            categoryId: 1,
+          });
+
+        expect(response.statusCode).to.equal(201);
+        expect(response.body)
+          .to.have.property('body')
+          .that.has.property('id');
+      });
+    });
   });
 
   describe('news tests on failure', () => {
@@ -116,6 +135,63 @@ describe('news tests', () => {
         const response = await request(app)
           .get('/news/notanid/comments')
           .set('Authorization', `Bearer ${userToken}`);
+
+        expect(response.statusCode).to.equal(404);
+      });
+    });
+
+    describe('[POST - /news', () => {
+      it('should return 400 if request body is not valid', async () => {
+        const response = await request(app)
+          .post('/news')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({
+            name: 'title',
+            content: 'body',
+            image: 'https://foo.bar',
+            categoryId: 'not a number',
+          });
+
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 401 if no token provided', async () => {
+        const response = await request(app)
+          .post('/news')
+          .send({
+            name: 'title',
+            content: 'body',
+            image: 'https://foo.bar',
+            categoryId: 1,
+          });
+
+        expect(response.statusCode).to.equal(401);
+      });
+
+      it('should return 403 if user is not admin', async () => {
+        const response = await request(app)
+          .post('/news')
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({
+            name: 'title',
+            content: 'body',
+            image: 'https://foo.bar',
+            categoryId: 1,
+          });
+
+        expect(response.statusCode).to.equal(403);
+      });
+
+      it('should return 404 if category is not found', async () => {
+        const response = await request(app)
+          .post('/news')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({
+            name: 'title',
+            content: 'body',
+            image: 'https://foo.bar',
+            categoryId: -1,
+          });
 
         expect(response.statusCode).to.equal(404);
       });

--- a/test/news.test.js
+++ b/test/news.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+const request = require('supertest');
+const app = require('../app')
+
+describe('news tests on success', () => {
+  describe('[GET - /news]', () => {
+    it('Should return paginated array of news', async () => {
+      const response = await request(app).get('/news');
+
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.body)
+        .to.have.property('body')
+        .that.has.property('urls');
+
+      const { body: { body } } = response;
+
+      expect(body.urls)
+        .to.have.property('prevUrl')
+        .that.is.a.string;
+
+      expect(body.urls)
+        .to.have.property('nextUrl')
+        .that.is.a.string;
+
+      expect(Array.isArray(body.news)).to.be.true;
+    });
+  });
+});

--- a/test/news.test.js
+++ b/test/news.test.js
@@ -97,6 +97,22 @@ describe('news tests', () => {
           .that.has.property('id');
       });
     });
+
+    describe('[PUT - /news/:id', () => {
+      it('should update a new', async () => {
+        const response = await request(app)
+          .put('/news/1')
+          .set('Authorization', `Bearer ${adminToken}`)
+          .send({
+            name: 'edited',
+          });
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.body)
+          .to.have.property('body')
+          .that.has.property('name', 'edited');
+      });
+    });
   });
 
   describe('news tests on failure', () => {
@@ -195,6 +211,77 @@ describe('news tests', () => {
 
         expect(response.statusCode).to.equal(404);
       });
+    });
+  });
+
+  describe('[PUT - /news/:id', () => {
+    it('should return 400 if request body is not valid', async () => {
+      const response = await request(app)
+        .put('/news/1')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'title',
+          content: 'body',
+          image: 'https://foo.bar',
+          categoryId: 'not a number',
+        });
+
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 401 if no token provided', async () => {
+      const response = await request(app)
+        .put('/news/1')
+        .send({
+          name: 'title',
+          content: 'body',
+          image: 'https://foo.bar',
+          categoryId: 1,
+        });
+
+      expect(response.statusCode).to.equal(401);
+    });
+
+    it('should return 403 if user is not admin', async () => {
+      const response = await request(app)
+        .put('/news/1')
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({
+          name: 'title',
+          content: 'body',
+          image: 'https://foo.bar',
+          categoryId: 1,
+        });
+
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should return 404 if new is not found', async () => {
+      const response = await request(app)
+        .put('/news/notanid')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'title',
+          content: 'body',
+          image: 'https://foo.bar',
+          categoryId: 1,
+        });
+
+      expect(response.statusCode).to.equal(404);
+    });
+
+    it('should return 404 if category is not found', async () => {
+      const response = await request(app)
+        .put('/news/1')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          name: 'title',
+          content: 'body',
+          image: 'https://foo.bar',
+          categoryId: -1,
+        });
+
+      expect(response.statusCode).to.equal(404);
     });
   });
 });


### PR DESCRIPTION
## Descripción

COMO desarrollador
QUIERO disponer de tests de los endpoints de /news
PARA asegurar la integridad y funcionamiento del proyecto

### Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.

## Evidencia

![image](https://user-images.githubusercontent.com/58740322/184788814-2cba8a45-a6c3-4ec1-a505-34bc220f57cc.png)